### PR TITLE
Render multiple meshes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,9 +35,11 @@ add_executable(
         ${SRC_DIR}/App.cpp
         ${SRC_DIR}/App.h
         ${SRC_DIR}/AppConfig.h
+        ${SRC_DIR}/graphics/Model.h
         ${SRC_DIR}/graphics/Quad.h
         ${SRC_DIR}/graphics/Renderer.cpp
         ${SRC_DIR}/graphics/Renderer.h
+        ${SRC_DIR}/graphics/SimplePushConstantData.h
         ${SRC_DIR}/graphics/Texture.cpp
         ${SRC_DIR}/graphics/Texture.h
         ${SRC_DIR}/graphics/UniformBufferObject.h

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,17 +35,18 @@ add_executable(
         ${SRC_DIR}/App.cpp
         ${SRC_DIR}/App.h
         ${SRC_DIR}/AppConfig.h
-        ${SRC_DIR}/graphics/Model.h
+        ${SRC_DIR}/graphics/Mesh.h
         ${SRC_DIR}/graphics/Quad.h
         ${SRC_DIR}/graphics/Renderer.cpp
         ${SRC_DIR}/graphics/Renderer.h
-        ${SRC_DIR}/graphics/SimplePushConstantData.h
+        ${SRC_DIR}/graphics/PushConstantData.h
         ${SRC_DIR}/graphics/Texture.cpp
         ${SRC_DIR}/graphics/Texture.h
-        ${SRC_DIR}/graphics/UniformBufferObject.h
+        ${SRC_DIR}/graphics/UniformBufferData.h
         ${SRC_DIR}/graphics/Vertex.h
         ${SRC_DIR}/graphics/VertexAttribute.cpp
         ${SRC_DIR}/graphics/VertexAttribute.h
+        ${SRC_DIR}/graphics/ViewProjection.h
         ${SRC_DIR}/graphics/VulkanApp.cpp
         ${SRC_DIR}/graphics/VulkanApp.h
         ${SRC_DIR}/graphics/VulkanBuffer.cpp

--- a/res/shaders/shader.frag
+++ b/res/shaders/shader.frag
@@ -1,12 +1,14 @@
 #version 450
 
-layout(binding = 1) uniform sampler2D texSampler;
+layout(binding = 1) uniform sampler2D textureSampler;
 
-layout(location = 0) in vec3 fragColor;
-layout(location = 1) in vec2 fragTexCoord;
+layout(location = 0) in VertexOutput {
+    vec3 color;
+    vec2 textureCoordinate;
+} vertexOutput;
 
 layout(location = 0) out vec4 outColor;
 
 void main() {
-    outColor = texture(texSampler, fragTexCoord * 2.0);
+    outColor = texture(textureSampler, vertexOutput.textureCoordinate);
 }

--- a/res/shaders/shader.vert
+++ b/res/shaders/shader.vert
@@ -1,24 +1,25 @@
 #version 450
 
-layout(binding = 0) uniform UniformBufferObject {
-    //mat4 model;
+layout(binding = 0) uniform UniformBufferData {
     mat4 view;
-    mat4 proj;
-} ubo;
+    mat4 projection;
+} uniformBufferData;
 
-layout(push_constant) uniform Push {
-    mat4 modelMatrix;
-} push;
+layout(push_constant) uniform PushConstantData {
+    mat4 model;
+} pushConstantData;
 
-layout(location = 0) in vec3 inPosition;
-layout(location = 1) in vec3 inColor;
-layout(location = 2) in vec2 inTexCoord;
+layout(location = 0) in vec3 position;
+layout(location = 1) in vec3 color;
+layout(location = 2) in vec2 textureCoordinate;
 
-layout(location = 0) out vec3 fragColor;
-layout(location = 1) out vec2 fragTexCoord;
+layout(location = 0) out VertexOutput {
+    vec3 color;
+    vec2 textureCoordinate;
+} vertexOutput;
 
 void main() {
-    gl_Position = ubo.proj * ubo.view * push.modelMatrix * vec4(inPosition, 1.0);
-    fragColor = inColor;
-    fragTexCoord = inTexCoord;
+    gl_Position = uniformBufferData.projection * uniformBufferData.view * pushConstantData.model * vec4(position, 1.0);
+    vertexOutput.color = color;
+    vertexOutput.textureCoordinate = textureCoordinate;
 }

--- a/res/shaders/shader.vert
+++ b/res/shaders/shader.vert
@@ -1,10 +1,14 @@
 #version 450
 
 layout(binding = 0) uniform UniformBufferObject {
-    mat4 model;
+    //mat4 model;
     mat4 view;
     mat4 proj;
 } ubo;
+
+layout(push_constant) uniform Push {
+    mat4 modelMatrix;
+} push;
 
 layout(location = 0) in vec3 inPosition;
 layout(location = 1) in vec3 inColor;
@@ -14,7 +18,7 @@ layout(location = 0) out vec3 fragColor;
 layout(location = 1) out vec2 fragTexCoord;
 
 void main() {
-    gl_Position = ubo.proj * ubo.view * ubo.model * vec4(inPosition, 1.0);
+    gl_Position = ubo.proj * ubo.view * push.modelMatrix * vec4(inPosition, 1.0);
     fragColor = inColor;
     fragTexCoord = inTexCoord;
 }

--- a/src/App.cpp
+++ b/src/App.cpp
@@ -51,7 +51,9 @@ namespace Blink {
 
         SceneConfig sceneConfig{};
         sceneConfig.keyboard = keyboard;
+        sceneConfig.renderer = renderer;
         sceneConfig.luaEngine = luaEngine;
+        sceneConfig.camera = camera;
         BL_EXECUTE_THROW(scene = new Scene(sceneConfig));
     }
 
@@ -90,20 +92,12 @@ namespace Blink {
         lastTime = time;
 
         camera->update(timestep);
-
-        glm::mat4 playerModel = scene->update(timestep);
-
-        Frame frame{};
-        frame.model = playerModel;
-        frame.view = camera->getViewMatrix();
-        frame.projection = camera->getProjectionMatrix();
-
-        renderer->render(frame);
+        scene->update(timestep);
 
         fps++;
         fpsUpdateTimestep += timestep;
         if (fpsUpdateTimestep >= 1.0) {
-            BL_LOG_DEBUG("FPS [{}]", fps);
+            BL_LOG_INFO("FPS [{}]", fps);
             fps = 0;
             fpsUpdateTimestep = 0;
         }

--- a/src/App.cpp
+++ b/src/App.cpp
@@ -91,9 +91,6 @@ namespace Blink {
         double timestep = time - lastTime;
         lastTime = time;
 
-        camera->update(timestep);
-        scene->update(timestep);
-
         fps++;
         fpsUpdateTimestep += timestep;
         if (fpsUpdateTimestep >= 1.0) {
@@ -101,6 +98,11 @@ namespace Blink {
             fps = 0;
             fpsUpdateTimestep = 0;
         }
+
+        camera->update(timestep);
+        scene->update(timestep);
+
+        scene->render();
     }
 
     void App::onEvent(Event& event) const {

--- a/src/App.cpp
+++ b/src/App.cpp
@@ -76,6 +76,7 @@ namespace Blink {
             BL_LOG_INFO("Running...");
             while (!window->shouldClose()) {
                 update();
+                render();
             }
         } catch (const Error& e) {
             BL_LOG_CRITICAL("Runtime error");
@@ -101,8 +102,14 @@ namespace Blink {
 
         camera->update(timestep);
         scene->update(timestep);
+    }
 
+    void App::render() const {
+        if (!renderer->beginFrame()) {
+            return;
+        }
         scene->render();
+        renderer->endFrame();
     }
 
     void App::onEvent(Event& event) const {

--- a/src/App.h
+++ b/src/App.h
@@ -38,6 +38,8 @@ namespace Blink {
 
         void update();
 
+        void render() const;
+
         void onEvent(Event& event) const;
     };
 }

--- a/src/graphics/Mesh.h
+++ b/src/graphics/Mesh.h
@@ -11,14 +11,14 @@
 #include <vector>
 
 namespace Blink {
-    struct Model {
-        glm::mat4 modelMatrix;
+    struct Mesh {
+        glm::mat4 model;
         std::vector<Vertex> vertices;
         std::vector<uint16_t> indices;
-        VulkanImage* texture = nullptr;
         VulkanVertexBuffer* vertexBuffer = nullptr;
         VulkanIndexBuffer* indexBuffer = nullptr;
         VulkanUniformBuffer* uniformBuffer = nullptr;
+        VulkanImage* texture = nullptr;
         VkDescriptorSet descriptorSet = VK_NULL_HANDLE;
     };
 }

--- a/src/graphics/Model.h
+++ b/src/graphics/Model.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include "graphics/Vertex.h"
+#include "graphics/VulkanImage.h"
+#include "graphics/VulkanVertexBuffer.h"
+#include "graphics/VulkanIndexBuffer.h"
+#include "graphics/VulkanUniformBuffer.h"
+
+#include <glm/glm.hpp>
+#include <vulkan/vulkan.h>
+#include <vector>
+
+namespace Blink {
+    struct Model {
+        glm::mat4 modelMatrix;
+        std::vector<Vertex> vertices;
+        std::vector<uint16_t> indices;
+        VulkanImage* texture = nullptr;
+        VulkanVertexBuffer* vertexBuffer = nullptr;
+        VulkanIndexBuffer* indexBuffer = nullptr;
+        VulkanUniformBuffer* uniformBuffer = nullptr;
+        VkDescriptorSet descriptorSet = VK_NULL_HANDLE;
+    };
+}

--- a/src/graphics/PushConstantData.h
+++ b/src/graphics/PushConstantData.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#include <glm/glm.hpp>
+
+namespace Blink {
+    struct PushConstantData {
+        alignas(16) glm::mat4 model;
+    };
+}

--- a/src/graphics/Renderer.cpp
+++ b/src/graphics/Renderer.cpp
@@ -40,14 +40,14 @@ namespace Blink {
         vertexBufferConfig.commandPool = commandPool;
         vertexBufferConfig.size = sizeof(vertices[0]) * vertices.size();
         vertexBuffer = new VulkanVertexBuffer(vertexBufferConfig);
-        vertexBuffer->setData(vertices);
+        //vertexBuffer->setData(vertices);
 
         VulkanIndexBufferConfig indexBufferConfig{};
         indexBufferConfig.device = device;
         indexBufferConfig.commandPool = commandPool;
         indexBufferConfig.size = sizeof(indices[0]) * indices.size();
         indexBuffer = new VulkanIndexBuffer(indexBufferConfig);
-        indexBuffer->setData(indices);
+        //indexBuffer->setData(indices);
 
         for (size_t i = 0; i < MAX_FRAMES_IN_FLIGHT; i++) {
             VulkanUniformBufferConfig uniformBufferConfig{};
@@ -119,6 +119,10 @@ namespace Blink {
         const VulkanUniformBuffer* uniformBuffer = uniformBuffers[currentFrame];
         const VkDescriptorSet descriptorSet = descriptorSets[currentFrame];
 
+        setUniformData(uniformBuffer, frame);
+        vertexBuffer->setData(*frame.vertices);
+        indexBuffer->setData(*frame.indices);
+
         BL_ASSERT_THROW_VK_SUCCESS(commandBuffer.begin());
 
         swapChain->beginRenderPass(commandBuffer);
@@ -130,8 +134,6 @@ namespace Blink {
         swapChain->endRenderPass(commandBuffer);
 
         BL_ASSERT_THROW_VK_SUCCESS(commandBuffer.end());
-
-        setUniformData(uniformBuffer, frame);
 
         swapChain->endFrame(commandBuffer);
         currentFrame = (currentFrame + 1) % MAX_FRAMES_IN_FLIGHT;
@@ -147,9 +149,9 @@ namespace Blink {
 
     void Renderer::setUniformData(const VulkanUniformBuffer* uniformBuffer, const Frame& frame) const {
         UniformBufferObject ubo{};
-        ubo.model = frame.model;
-        ubo.view = frame.view;
-        ubo.proj = frame.projection;
+        ubo.model = *frame.model;
+        ubo.view = *frame.view;
+        ubo.proj = *frame.projection;
 
         // GLM was originally designed for OpenGL, where the Y coordinate of the clip coordinates is inverted.
         // The easiest way to compensate for that is to flip the sign on the scaling factor of the Y rotationAxis in the projection matrix.

--- a/src/graphics/Renderer.h
+++ b/src/graphics/Renderer.h
@@ -25,9 +25,11 @@
 
 namespace Blink {
     struct Frame {
-        glm::mat4 model;
-        glm::mat4 view;
-        glm::mat4 projection;
+        glm::mat4* model;
+        glm::mat4* view;
+        glm::mat4* projection;
+        std::vector<Vertex>* vertices;
+        std::vector<uint16_t>* indices;
     };
 
     struct RendererConfig {

--- a/src/graphics/Renderer.h
+++ b/src/graphics/Renderer.h
@@ -19,17 +19,18 @@
 #include "graphics/VulkanImage.h"
 #include "graphics/Quad.h"
 #include "graphics/Vertex.h"
+#include "graphics/Model.h"
 
 #include <vulkan/vulkan.h>
 #include <glm/glm.hpp>
 
 namespace Blink {
     struct Frame {
-        glm::mat4* model;
+        //glm::mat4* model;
         glm::mat4* view;
         glm::mat4* projection;
-        std::vector<Vertex>* vertices;
-        std::vector<uint16_t>* indices;
+        //std::vector<Vertex>* vertices;
+        //std::vector<uint16_t>* indices;
     };
 
     struct RendererConfig {
@@ -51,10 +52,7 @@ namespace Blink {
         VulkanCommandPool* commandPool = nullptr;
         std::vector<VulkanCommandBuffer> commandBuffers;
         VulkanSwapChain* swapChain = nullptr;
-        VulkanVertexBuffer* vertexBuffer = nullptr;
-        VulkanIndexBuffer* indexBuffer = nullptr;
         std::vector<VulkanUniformBuffer*> uniformBuffers;
-        VulkanImage* textureImage;
         VkSampler textureSampler;
         VkDescriptorSetLayout descriptorSetLayout = nullptr;
         VkDescriptorPool descriptorPool = nullptr;
@@ -64,40 +62,27 @@ namespace Blink {
         VulkanGraphicsPipeline* graphicsPipeline = nullptr;
         uint32_t currentFrame = 0;
 
-    private:
-        const std::vector<Vertex> vertices = {
-            {{-0.5f, -0.5f, 0.0f}, {1.0f, 0.0f, 0.0f}, {0.0f, 0.0f}},
-            {{0.5f, -0.5f, 0.0f}, {0.0f, 1.0f, 0.0f}, {1.0f, 0.0f}},
-            {{0.5f, 0.5f, 0.0f}, {0.0f, 0.0f, 1.0f}, {1.0f, 1.0f}},
-            {{-0.5f, 0.5f, 0.0f}, {1.0f, 1.0f, 1.0f}, {0.0f, 1.0f}},
-
-            {{-0.5f, -0.5f, -0.5f}, {1.0f, 0.0f, 0.0f}, {0.0f, 0.0f}},
-            {{0.5f, -0.5f, -0.5f}, {0.0f, 1.0f, 0.0f}, {1.0f, 0.0f}},
-            {{0.5f, 0.5f, -0.5f}, {0.0f, 0.0f, 1.0f}, {1.0f, 1.0f}},
-            {{-0.5f, 0.5f, -0.5f}, {1.0f, 1.0f, 1.0f}, {0.0f, 1.0f}}
-        };
-        const std::vector<uint16_t> indices = {
-            0, 1, 2, 2, 3, 0,
-            4, 5, 6, 6, 7, 4
-        };
-
     public:
-        explicit Renderer(const RendererConfig& config) noexcept(false);
+        explicit Renderer(const RendererConfig& config);
 
         ~Renderer();
 
-        void waitUntilIdle() const noexcept(false);
-
-        void render(const Frame& frame) noexcept(false);
+        void waitUntilIdle() const;
 
         void onEvent(Event& event);
 
+        bool beginFrame(const Frame& frame) const;
+
+        void render(const Frame& frame, const Model& model) const;
+
+        void endFrame();
+
+        Model createModel() const;
+
+        void destroyModel(const Model& model) const;
+
     private:
         void setUniformData(const VulkanUniformBuffer* uniformBuffer, const Frame& frame) const;
-
-        void bindDescriptorSet(VkDescriptorSet descriptorSet, const VulkanCommandBuffer& commandBuffer) const;
-
-        void drawIndexed(const VulkanCommandBuffer& commandBuffer) const;
 
         void reloadShaders();
 

--- a/src/graphics/Renderer.h
+++ b/src/graphics/Renderer.h
@@ -19,20 +19,13 @@
 #include "graphics/VulkanImage.h"
 #include "graphics/Quad.h"
 #include "graphics/Vertex.h"
-#include "graphics/Model.h"
+#include "graphics/Mesh.h"
+#include "graphics/ViewProjection.h"
 
 #include <vulkan/vulkan.h>
 #include <glm/glm.hpp>
 
 namespace Blink {
-    struct Frame {
-        //glm::mat4* model;
-        glm::mat4* view;
-        glm::mat4* projection;
-        //std::vector<Vertex>* vertices;
-        //std::vector<uint16_t>* indices;
-    };
-
     struct RendererConfig {
         std::string applicationName;
         std::string engineName;
@@ -52,15 +45,14 @@ namespace Blink {
         VulkanCommandPool* commandPool = nullptr;
         std::vector<VulkanCommandBuffer> commandBuffers;
         VulkanSwapChain* swapChain = nullptr;
-        std::vector<VulkanUniformBuffer*> uniformBuffers;
         VkSampler textureSampler;
         VkDescriptorSetLayout descriptorSetLayout = nullptr;
         VkDescriptorPool descriptorPool = nullptr;
-        std::vector<VkDescriptorSet> descriptorSets;
         VulkanShader* vertexShader = nullptr;
         VulkanShader* fragmentShader = nullptr;
         VulkanGraphicsPipeline* graphicsPipeline = nullptr;
         uint32_t currentFrame = 0;
+        VulkanCommandBuffer currentCommandBuffer = nullptr;
 
     public:
         explicit Renderer(const RendererConfig& config);
@@ -71,18 +63,24 @@ namespace Blink {
 
         void onEvent(Event& event);
 
-        bool beginFrame(const Frame& frame) const;
+        bool beginFrame();
 
-        void render(const Frame& frame, const Model& model) const;
+        void renderMesh(const Mesh& mesh, const ViewProjection& viewProjection) const;
 
         void endFrame();
 
-        Model createModel() const;
+        Mesh createMesh() const;
 
-        void destroyModel(const Model& model) const;
+        void destroyMesh(const Mesh& mesh) const;
 
     private:
-        void setUniformData(const VulkanUniformBuffer* uniformBuffer, const Frame& frame) const;
+        void setMeshUniformData(const Mesh& mesh, const ViewProjection& viewProjection) const;
+
+        void setMeshPushConstantData(const Mesh& mesh) const;
+
+        void bindMesh(const Mesh& mesh) const;
+
+        void drawMeshIndexed(const Mesh& mesh) const;
 
         void reloadShaders();
 
@@ -93,8 +91,6 @@ namespace Blink {
         void createDescriptorSetLayout();
 
         void createDescriptorPool();
-
-        void createDescriptorSets();
 
         void createGraphicsPipelineObjects();
 

--- a/src/graphics/SimplePushConstantData.h
+++ b/src/graphics/SimplePushConstantData.h
@@ -1,9 +1,0 @@
-#pragma once
-
-#include <glm/glm.hpp>
-
-namespace Blink {
-    struct SimplePushConstantData {
-        glm::mat4 modelMatrix{1.f};
-    };
-}

--- a/src/graphics/SimplePushConstantData.h
+++ b/src/graphics/SimplePushConstantData.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#include <glm/glm.hpp>
+
+namespace Blink {
+    struct SimplePushConstantData {
+        glm::mat4 modelMatrix{1.f};
+    };
+}

--- a/src/graphics/UniformBufferData.h
+++ b/src/graphics/UniformBufferData.h
@@ -1,0 +1,8 @@
+#pragma once
+
+#include <glm/glm.hpp>
+
+struct UniformBufferData {
+    alignas(16) glm::mat4 view;
+    alignas(16) glm::mat4 projection;
+};

--- a/src/graphics/UniformBufferObject.h
+++ b/src/graphics/UniformBufferObject.h
@@ -1,9 +1,0 @@
-#pragma once
-
-#include <glm/glm.hpp>
-
-struct UniformBufferObject {
-    //alignas(16) glm::mat4 model;
-    alignas(16) glm::mat4 view;
-    alignas(16) glm::mat4 proj;
-};

--- a/src/graphics/UniformBufferObject.h
+++ b/src/graphics/UniformBufferObject.h
@@ -3,7 +3,7 @@
 #include <glm/glm.hpp>
 
 struct UniformBufferObject {
-    alignas(16) glm::mat4 model;
+    //alignas(16) glm::mat4 model;
     alignas(16) glm::mat4 view;
     alignas(16) glm::mat4 proj;
 };

--- a/src/graphics/ViewProjection.h
+++ b/src/graphics/ViewProjection.h
@@ -1,0 +1,8 @@
+#pragma once
+
+namespace Blink {
+    struct ViewProjection {
+        glm::mat4 view;
+        glm::mat4 projection;
+    };
+}

--- a/src/graphics/VulkanApp.cpp
+++ b/src/graphics/VulkanApp.cpp
@@ -23,7 +23,7 @@ namespace Blink {
 
 namespace Blink {
 
-    VulkanApp::VulkanApp(const VulkanAppConfig& config) noexcept(false) : config(config) {
+    VulkanApp::VulkanApp(const VulkanAppConfig& config) : config(config) {
         BL_ASSERT_THROW(config.window->isVulkanSupported());
 
         std::vector<const char*> requiredExtensions = config.window->getRequiredVulkanExtensions();
@@ -76,7 +76,7 @@ namespace Blink {
         const std::vector<const char*>& requiredExtensions,
         const std::vector<const char*>& validationLayers,
         const VkDebugUtilsMessengerCreateInfoEXT& debugMessengerCreateInfo
-    ) noexcept(false) {
+    ) {
         VkApplicationInfo appInfo{};
         appInfo.sType = VK_STRUCTURE_TYPE_APPLICATION_INFO;
         appInfo.pApplicationName = config.applicationName.c_str();
@@ -108,7 +108,7 @@ namespace Blink {
         BL_LOG_INFO("Destroyed instance");
     }
 
-    void VulkanApp::createDebugMessenger(const VkDebugUtilsMessengerCreateInfoEXT& debugMessengerCreateInfo) noexcept(false) {
+    void VulkanApp::createDebugMessenger(const VkDebugUtilsMessengerCreateInfoEXT& debugMessengerCreateInfo) {
         auto createDebugMessenger = (PFN_vkCreateDebugUtilsMessengerEXT) vkGetInstanceProcAddr(instance, "vkCreateDebugUtilsMessengerEXT");
         BL_ASSERT_THROW(createDebugMessenger != nullptr);
         BL_ASSERT_VK_SUCCESS(createDebugMessenger(instance, &debugMessengerCreateInfo, BL_VULKAN_ALLOCATOR, &debugMessenger));
@@ -124,7 +124,7 @@ namespace Blink {
         BL_LOG_INFO("Destroyed debug messenger");
     }
 
-    void VulkanApp::createSurface() noexcept(false) {
+    void VulkanApp::createSurface() {
         BL_ASSERT_VK_SUCCESS(config.window->createVulkanSurface(instance, &surface, BL_VULKAN_ALLOCATOR));
         BL_LOG_INFO("Created surface");
     }

--- a/src/graphics/VulkanApp.h
+++ b/src/graphics/VulkanApp.h
@@ -25,7 +25,7 @@ namespace Blink {
         VkSurfaceKHR surface = nullptr;
 
     public:
-        VulkanApp(const VulkanAppConfig& config) noexcept(false);
+        VulkanApp(const VulkanAppConfig& config);
 
         ~VulkanApp();
 
@@ -38,15 +38,15 @@ namespace Blink {
             const std::vector<const char*>& requiredExtensions,
             const std::vector<const char*>& validationLayers,
             const VkDebugUtilsMessengerCreateInfoEXT& debugMessengerCreateInfo
-        ) noexcept(false);
+        );
 
         void destroyInstance() const;
 
-        void createDebugMessenger(const VkDebugUtilsMessengerCreateInfoEXT& debugMessengerCreateInfo) noexcept(false);
+        void createDebugMessenger(const VkDebugUtilsMessengerCreateInfoEXT& debugMessengerCreateInfo);
 
         void destroyDebugMessenger() const;
 
-        void createSurface() noexcept(false);
+        void createSurface();
 
         void destroySurface() const;
 

--- a/src/graphics/VulkanBuffer.cpp
+++ b/src/graphics/VulkanBuffer.cpp
@@ -2,7 +2,7 @@
 #include "VulkanBuffer.h"
 
 namespace Blink {
-    VulkanBuffer::VulkanBuffer(const VulkanBufferConfig& config) noexcept(false) : config(config) {
+    VulkanBuffer::VulkanBuffer(const VulkanBufferConfig& config) : config(config) {
         VkBufferCreateInfo bufferCreateInfo{};
         bufferCreateInfo.sType = VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO;
         bufferCreateInfo.size = config.size;
@@ -34,18 +34,18 @@ namespace Blink {
         return buffer;
     }
 
-    void VulkanBuffer::setData(void* src) const noexcept(false) {
+    void VulkanBuffer::setData(void* src) const {
         void* dst;
         BL_ASSERT_THROW_VK_SUCCESS(config.device->mapMemory(memory, config.size, &dst));
         memcpy(dst, src, config.size);
         config.device->unmapMemory(memory);
     }
 
-    void VulkanBuffer::copyTo(VulkanBuffer* destinationBuffer) noexcept(false) {
+    void VulkanBuffer::copyTo(VulkanBuffer* destinationBuffer) {
         copy(this, destinationBuffer, config.device, config.commandPool);
     }
 
-    void VulkanBuffer::copyFrom(VulkanBuffer* sourceBuffer) noexcept(false) {
+    void VulkanBuffer::copyFrom(VulkanBuffer* sourceBuffer) {
         copy(sourceBuffer, this, config.device, config.commandPool);
     }
 
@@ -54,7 +54,7 @@ namespace Blink {
         VulkanBuffer* destinationBuffer,
         VulkanDevice* device,
         VulkanCommandPool* commandPool
-    ) noexcept(false) {
+    ) {
         BL_ASSERT(sourceBuffer->config.size == destinationBuffer->config.size);
 
         VulkanCommandBuffer commandBuffer;

--- a/src/graphics/VulkanBuffer.h
+++ b/src/graphics/VulkanBuffer.h
@@ -22,17 +22,17 @@ namespace Blink {
         VkDeviceMemory memory = nullptr;
 
     public:
-        explicit VulkanBuffer(const VulkanBufferConfig& config) noexcept(false);
+        explicit VulkanBuffer(const VulkanBufferConfig& config);
 
         ~VulkanBuffer();
 
         operator VkBuffer() const;
 
-        void setData(void* src) const noexcept(false);
+        void setData(void* src) const;
 
-        void copyFrom(VulkanBuffer* sourceBuffer) noexcept(false);
+        void copyFrom(VulkanBuffer* sourceBuffer);
 
-        void copyTo(VulkanBuffer* destinationBuffer) noexcept(false);
+        void copyTo(VulkanBuffer* destinationBuffer);
 
     public:
         static void copy(
@@ -40,6 +40,6 @@ namespace Blink {
             VulkanBuffer* destinationBuffer,
             VulkanDevice* device,
             VulkanCommandPool* commandPool
-        ) noexcept(false);
+        );
     };
 }

--- a/src/graphics/VulkanDevice.cpp
+++ b/src/graphics/VulkanDevice.cpp
@@ -3,7 +3,7 @@
 
 namespace Blink {
 
-    VulkanDevice::VulkanDevice(const VulkanDeviceConfig& config) noexcept(false) : config(config) {
+    VulkanDevice::VulkanDevice(const VulkanDeviceConfig& config) : config(config) {
         const QueueFamilyIndices& queueFamilyIndices = config.physicalDevice->getQueueFamilyIndices();
 
         createDevice(queueFamilyIndices);
@@ -271,7 +271,7 @@ namespace Blink {
         vkDestroySampler(device, sampler, BL_VULKAN_ALLOCATOR);
     }
 
-    void VulkanDevice::createDevice(const QueueFamilyIndices& queueFamilyIndices) noexcept(false) {
+    void VulkanDevice::createDevice(const QueueFamilyIndices& queueFamilyIndices) {
         const VkPhysicalDeviceFeatures features = config.physicalDevice->getFeatures();
 
         std::vector<const char*> extensionNames;

--- a/src/graphics/VulkanDevice.h
+++ b/src/graphics/VulkanDevice.h
@@ -23,7 +23,7 @@ namespace Blink {
         VkQueue presentQueue = nullptr;
 
     public:
-        explicit VulkanDevice(const VulkanDeviceConfig& config) noexcept(false);
+        explicit VulkanDevice(const VulkanDeviceConfig& config);
 
         ~VulkanDevice();
 
@@ -143,7 +143,7 @@ namespace Blink {
 
     private:
 
-        void createDevice(const QueueFamilyIndices& queueFamilyIndices) noexcept(false);
+        void createDevice(const QueueFamilyIndices& queueFamilyIndices);
 
         void destroyDevice() const;
 

--- a/src/graphics/VulkanGraphicsPipeline.cpp
+++ b/src/graphics/VulkanGraphicsPipeline.cpp
@@ -1,6 +1,6 @@
 #include "VulkanGraphicsPipeline.h"
 #include "Vertex.h"
-#include "SimplePushConstantData.h"
+#include "PushConstantData.h"
 
 namespace Blink {
     VulkanGraphicsPipeline::VulkanGraphicsPipeline(const VulkanGraphicsPipelineConfig& config) : config(config) {
@@ -86,7 +86,7 @@ namespace Blink {
         VkPushConstantRange pushConstantRange{};
         pushConstantRange.stageFlags = VK_SHADER_STAGE_VERTEX_BIT;
         pushConstantRange.offset = 0;
-        pushConstantRange.size = sizeof(SimplePushConstantData);
+        pushConstantRange.size = sizeof(PushConstantData);
 
         VkPipelineLayoutCreateInfo layoutCreateInfo{};
         layoutCreateInfo.sType = VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO;

--- a/src/graphics/VulkanGraphicsPipeline.cpp
+++ b/src/graphics/VulkanGraphicsPipeline.cpp
@@ -1,5 +1,6 @@
 #include "VulkanGraphicsPipeline.h"
 #include "Vertex.h"
+#include "SimplePushConstantData.h"
 
 namespace Blink {
     VulkanGraphicsPipeline::VulkanGraphicsPipeline(const VulkanGraphicsPipelineConfig& config) : config(config) {
@@ -82,10 +83,17 @@ namespace Blink {
         colorBlendStateCreateInfo.attachmentCount = 1;
         colorBlendStateCreateInfo.pAttachments = &colorBlendAttachmentState;
 
+        VkPushConstantRange pushConstantRange{};
+        pushConstantRange.stageFlags = VK_SHADER_STAGE_VERTEX_BIT;
+        pushConstantRange.offset = 0;
+        pushConstantRange.size = sizeof(SimplePushConstantData);
+
         VkPipelineLayoutCreateInfo layoutCreateInfo{};
         layoutCreateInfo.sType = VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO;
         layoutCreateInfo.setLayoutCount = 1;
         layoutCreateInfo.pSetLayouts = &config.descriptorSetLayout;
+        layoutCreateInfo.pushConstantRangeCount = 1;
+        layoutCreateInfo.pPushConstantRanges = &pushConstantRange;
 
         BL_ASSERT_THROW_VK_SUCCESS(config.device->createPipelineLayout(&layoutCreateInfo, &layout));
 

--- a/src/graphics/VulkanGraphicsPipeline.h
+++ b/src/graphics/VulkanGraphicsPipeline.h
@@ -22,7 +22,7 @@ namespace Blink {
         VkPipeline pipeline = nullptr;
 
     public:
-        explicit VulkanGraphicsPipeline(const VulkanGraphicsPipelineConfig& config) noexcept(false);
+        explicit VulkanGraphicsPipeline(const VulkanGraphicsPipelineConfig& config);
 
         ~VulkanGraphicsPipeline();
 

--- a/src/graphics/VulkanImage.h
+++ b/src/graphics/VulkanImage.h
@@ -31,7 +31,7 @@ namespace Blink {
         VkImageLayout currentLayout = VK_IMAGE_LAYOUT_UNDEFINED;
 
     public:
-        VulkanImage(const VulkanImageConfig& config) noexcept(false);
+        VulkanImage(const VulkanImageConfig& config);
 
         ~VulkanImage();
 
@@ -43,16 +43,16 @@ namespace Blink {
 
         VkImageView getImageView() const;
 
-        void setLayout(VkImageLayout layout) noexcept(false);
+        void setLayout(VkImageLayout layout);
 
-        void setData(const Image& image) const noexcept(false);
+        void setData(const Image& image) const;
 
     private:
-        void createImage() noexcept(false);
+        void createImage();
 
-        void createImageView() noexcept(false);
+        void createImageView();
 
-        void initializeImageMemory() noexcept(false);
+        void initializeImageMemory();
 
         static bool hasStencilComponent(VkFormat format);
 

--- a/src/graphics/VulkanIndexBuffer.cpp
+++ b/src/graphics/VulkanIndexBuffer.cpp
@@ -33,7 +33,7 @@ namespace Blink {
         return *buffer;
     }
 
-    void VulkanIndexBuffer::setData(const std::vector<uint16_t>& indices) const noexcept(false) {
+    void VulkanIndexBuffer::setData(const std::vector<uint16_t>& indices) const {
         stagingBuffer->setData((void*) indices.data());
         stagingBuffer->copyTo(buffer);
     }

--- a/src/graphics/VulkanIndexBuffer.h
+++ b/src/graphics/VulkanIndexBuffer.h
@@ -19,13 +19,13 @@ namespace Blink {
         VulkanBuffer* stagingBuffer = nullptr;
 
     public:
-        explicit VulkanIndexBuffer(const VulkanIndexBufferConfig& config) noexcept(false);
+        explicit VulkanIndexBuffer(const VulkanIndexBufferConfig& config);
 
         ~VulkanIndexBuffer();
 
         operator VkBuffer() const;
 
-        void setData(const std::vector<uint16_t>& indices) const noexcept(false);
+        void setData(const std::vector<uint16_t>& indices) const;
 
         void bind(VkCommandBuffer commandBuffer) const;
     };

--- a/src/graphics/VulkanPhysicalDevice.cpp
+++ b/src/graphics/VulkanPhysicalDevice.cpp
@@ -94,7 +94,6 @@ namespace Blink {
         VkPhysicalDevice physicalDevice,
         const std::vector<const char*>& requiredExtensions
     ) const {
-        BL_THROW("NOTICE ME");
         VkPhysicalDeviceProperties properties;
         vkGetPhysicalDeviceProperties(physicalDevice, &properties);
 

--- a/src/graphics/VulkanPhysicalDevice.cpp
+++ b/src/graphics/VulkanPhysicalDevice.cpp
@@ -3,7 +3,7 @@
 
 namespace Blink {
 
-    VulkanPhysicalDevice::VulkanPhysicalDevice(const VulkanPhysicalDeviceConfig& config) noexcept(false) : config(config) {
+    VulkanPhysicalDevice::VulkanPhysicalDevice(const VulkanPhysicalDeviceConfig& config) : config(config) {
         std::vector<VkPhysicalDevice> availableDevices = config.vulkanApp->getPhysicalDevices();
         BL_ASSERT_THROW(!availableDevices.empty());
 

--- a/src/graphics/VulkanPhysicalDevice.h
+++ b/src/graphics/VulkanPhysicalDevice.h
@@ -38,7 +38,7 @@ namespace Blink {
         VulkanPhysicalDeviceInfo deviceInfo{};
 
     public:
-        explicit VulkanPhysicalDevice(const VulkanPhysicalDeviceConfig& config) noexcept(false);
+        explicit VulkanPhysicalDevice(const VulkanPhysicalDeviceConfig& config);
 
         const std::vector<VkExtensionProperties>& getExtensions() const;
 

--- a/src/graphics/VulkanShader.cpp
+++ b/src/graphics/VulkanShader.cpp
@@ -1,7 +1,7 @@
 #include "VulkanShader.h"
 
 namespace Blink {
-    VulkanShader::VulkanShader(const VulkanShaderConfig& config) noexcept(false) : config(config) {
+    VulkanShader::VulkanShader(const VulkanShaderConfig& config) : config(config) {
         BL_ASSERT_THROW(config.bytes.size() > 0);
 
         VkShaderModuleCreateInfo shaderModuleCreateInfo{};

--- a/src/graphics/VulkanShader.h
+++ b/src/graphics/VulkanShader.h
@@ -17,7 +17,7 @@ namespace Blink {
         VkDescriptorSetLayout descriptorSetLayout = nullptr;
 
     public:
-        explicit VulkanShader(const VulkanShaderConfig& config) noexcept(false);
+        explicit VulkanShader(const VulkanShaderConfig& config);
 
         ~VulkanShader();
 
@@ -27,6 +27,6 @@ namespace Blink {
 
         void setLayout(VkDescriptorSetLayout layout);
 
-        void setLayout(const std::vector<VkDescriptorSetLayoutBinding>& bindings) noexcept(false);
+        void setLayout(const std::vector<VkDescriptorSetLayoutBinding>& bindings);
     };
 }

--- a/src/graphics/VulkanSwapChain.cpp
+++ b/src/graphics/VulkanSwapChain.cpp
@@ -38,7 +38,7 @@ namespace Blink {
         }
     }
 
-    bool VulkanSwapChain::beginFrame(uint32_t frameIndex) noexcept(false) {
+    bool VulkanSwapChain::beginFrame(uint32_t frameIndex) {
         currentInFlightFence = inFlightFences[frameIndex];
         currentImageAvailableSemaphore = imageAvailableSemaphores[frameIndex];
         currentRenderFinishedSemaphore = renderFinishedSemaphores[frameIndex];

--- a/src/graphics/VulkanSwapChain.h
+++ b/src/graphics/VulkanSwapChain.h
@@ -37,7 +37,7 @@ namespace Blink {
         bool windowResized = false;
 
     public:
-        explicit VulkanSwapChain(const VulkanSwapChainConfig& config) noexcept(false);
+        explicit VulkanSwapChain(const VulkanSwapChainConfig& config);
 
         ~VulkanSwapChain();
 
@@ -49,38 +49,38 @@ namespace Blink {
 
         void onEvent(Event& event);
 
-        bool beginFrame(uint32_t frameIndex) noexcept(false);
+        bool beginFrame(uint32_t frameIndex);
 
         void beginRenderPass(const VulkanCommandBuffer& commandBuffer) const;
 
         void endRenderPass(const VulkanCommandBuffer& commandBuffer) const;
 
-        void endFrame(const VulkanCommandBuffer& commandBuffer) noexcept(false);
+        void endFrame(const VulkanCommandBuffer& commandBuffer);
 
     private:
-        void recreateSwapChain() noexcept(false);
+        void recreateSwapChain();
 
-        void createSwapChain() noexcept(false);
+        void createSwapChain();
 
         void destroySwapChain() const;
 
-        void createColorImages() noexcept(false);
+        void createColorImages();
 
         void destroyColorImages();
 
-        void createDepthImage() noexcept(false);
+        void createDepthImage();
 
         void destroyDepthImage() const;
 
-        void createRenderPass() noexcept(false);
+        void createRenderPass();
 
         void destroyRenderPass() const;
 
-        void createFramebuffers() noexcept(false);
+        void createFramebuffers();
 
         void destroyFramebuffers() const;
 
-        void createSyncObjects() noexcept(false);
+        void createSyncObjects();
 
         void destroySyncObjects() const;
 

--- a/src/graphics/VulkanVertexBuffer.cpp
+++ b/src/graphics/VulkanVertexBuffer.cpp
@@ -3,7 +3,7 @@
 
 namespace Blink {
 
-    VulkanVertexBuffer::VulkanVertexBuffer(const VulkanVertexBufferConfig& config) noexcept(false) : config(config) {
+    VulkanVertexBuffer::VulkanVertexBuffer(const VulkanVertexBufferConfig& config) : config(config) {
         BL_ASSERT_THROW(config.size > 0);
 
         VulkanBufferConfig bufferConfig{};
@@ -34,7 +34,7 @@ namespace Blink {
         return *buffer;
     }
 
-    void VulkanVertexBuffer::setData(const std::vector<Vertex>& vertices) const noexcept(false) {
+    void VulkanVertexBuffer::setData(const std::vector<Vertex>& vertices) const {
         stagingBuffer->setData((void*) vertices.data());
         stagingBuffer->copyTo(buffer);
     }

--- a/src/graphics/VulkanVertexBuffer.h
+++ b/src/graphics/VulkanVertexBuffer.h
@@ -22,13 +22,13 @@ namespace Blink {
         VulkanBuffer* stagingBuffer = nullptr;
 
     public:
-        explicit VulkanVertexBuffer(const VulkanVertexBufferConfig& config) noexcept(false);
+        explicit VulkanVertexBuffer(const VulkanVertexBufferConfig& config);
 
         ~VulkanVertexBuffer();
 
         operator VkBuffer() const;
 
-        void setData(const std::vector<Vertex>& vertices) const noexcept(false);
+        void setData(const std::vector<Vertex>& vertices) const;
 
         void bind(VkCommandBuffer commandBuffer) const;
     };

--- a/src/lua/EntityLuaBinding.h
+++ b/src/lua/EntityLuaBinding.h
@@ -9,7 +9,7 @@ namespace Blink {
         entt::registry* entityRegistry;
 
     private:
-        EntityLuaBinding(entt::registry* entityRegistry);
+        explicit EntityLuaBinding(entt::registry* entityRegistry);
 
         ~EntityLuaBinding() = default;
 

--- a/src/lua/LuaEngine.cpp
+++ b/src/lua/LuaEngine.cpp
@@ -48,7 +48,7 @@ namespace Blink {
                     tableName,
                     lua_tostring(L, -1)
                 );
-                throw std::runtime_error("Could not load Lua script");
+                BL_THROW("Could not load Lua script");
             }
             BL_LOG_INFO(
                 "Loaded Lua script [{}] for entity of type [{}]",
@@ -80,7 +80,7 @@ namespace Blink {
                     entity,
                     lua_tostring(L, -1)
                 );
-                throw std::runtime_error("Could not update Lua script for entity");
+                BL_THROW("Could not update Lua script for entity");
             }
 
             lua_pop(L, lua_gettop(L));

--- a/src/lua/LuaEngine.cpp
+++ b/src/lua/LuaEngine.cpp
@@ -28,7 +28,7 @@ namespace Blink {
     }
 
     void LuaEngine::reloadScripts(entt::registry* entityRegistry) const {
-        compileLuaFiles();
+        compileLuaScripts();
         createEntityBindings(entityRegistry);
         BL_LOG_INFO("Reloaded Lua scripts");
     }
@@ -91,7 +91,7 @@ namespace Blink {
         KeyboardLuaBinding::initialize(L, config.keyboard);
     }
 
-    void LuaEngine::compileLuaFiles() {
+    void LuaEngine::compileLuaScripts() {
         std::stringstream ss;
         ss << "cmake";
         ss << " -D LUA_SOURCE_DIR=" << CMAKE_LUA_SOURCE_DIR;

--- a/src/lua/LuaEngine.h
+++ b/src/lua/LuaEngine.h
@@ -29,7 +29,7 @@ namespace Blink {
     private:
         void createGlobalBindings() const;
 
-        static void compileLuaFiles();
+        static void compileLuaScripts();
 
         static int luaPrint(lua_State* L);
     };

--- a/src/scene/Camera.cpp
+++ b/src/scene/Camera.cpp
@@ -8,11 +8,11 @@ namespace Blink {
         updateDirections();
     }
 
-    glm::mat4 Camera::getViewMatrix() const {
+    glm::mat4 Camera::getView() const {
         return glm::lookAt(position, position + frontDirection, upDirection);
     }
 
-    glm::mat4 Camera::getProjectionMatrix() const {
+    glm::mat4 Camera::getProjection() const {
         return glm::perspective(fieldOfView, aspectRatio, nearClip, farClip);
     }
 

--- a/src/scene/Camera.h
+++ b/src/scene/Camera.h
@@ -32,9 +32,9 @@ namespace Blink {
     public:
         explicit Camera(const CameraConfig& config);
 
-        glm::mat4 getViewMatrix() const;
+        glm::mat4 getView() const;
 
-        glm::mat4 getProjectionMatrix() const;
+        glm::mat4 getProjection() const;
 
         void update(double timestep);
 

--- a/src/scene/Components.h
+++ b/src/scene/Components.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "graphics/Vertex.h"
-#include "graphics/Model.h"
+#include "graphics/Mesh.h"
 
 #include <glm/glm.hpp>
 #include <string>
@@ -20,7 +20,7 @@ namespace Blink {
         std::string filepath;
     };
 
-    struct ModelComponent {
-        Model model;
+    struct MeshComponent {
+        Mesh mesh;
     };
 }

--- a/src/scene/Components.h
+++ b/src/scene/Components.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "system/Uuid.h"
+#include "graphics/Vertex.h"
 
 #include <glm/glm.hpp>
 #include <string>
@@ -17,5 +17,23 @@ namespace Blink {
     struct LuaComponent {
         std::string type;
         std::string filepath;
+    };
+
+    struct ModelComponent {
+        std::vector<Vertex> vertices = {
+            {{-0.5f, -0.5f, 0.0f}, {1.0f, 0.0f, 0.0f}, {0.0f, 0.0f}},
+            {{0.5f, -0.5f, 0.0f}, {0.0f, 1.0f, 0.0f}, {1.0f, 0.0f}},
+            {{0.5f, 0.5f, 0.0f}, {0.0f, 0.0f, 1.0f}, {1.0f, 1.0f}},
+            {{-0.5f, 0.5f, 0.0f}, {1.0f, 1.0f, 1.0f}, {0.0f, 1.0f}},
+
+            {{-0.5f, -0.5f, -0.5f}, {1.0f, 0.0f, 0.0f}, {0.0f, 0.0f}},
+            {{0.5f, -0.5f, -0.5f}, {0.0f, 1.0f, 0.0f}, {1.0f, 0.0f}},
+            {{0.5f, 0.5f, -0.5f}, {0.0f, 0.0f, 1.0f}, {1.0f, 1.0f}},
+            {{-0.5f, 0.5f, -0.5f}, {1.0f, 1.0f, 1.0f}, {0.0f, 1.0f}}
+        };
+        std::vector<uint16_t> indices = {
+            0, 1, 2, 2, 3, 0,
+            4, 5, 6, 6, 7, 4
+        };
     };
 }

--- a/src/scene/Components.h
+++ b/src/scene/Components.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "graphics/Vertex.h"
+#include "graphics/Model.h"
 
 #include <glm/glm.hpp>
 #include <string>
@@ -20,20 +21,6 @@ namespace Blink {
     };
 
     struct ModelComponent {
-        std::vector<Vertex> vertices = {
-            {{-0.5f, -0.5f, 0.0f}, {1.0f, 0.0f, 0.0f}, {0.0f, 0.0f}},
-            {{0.5f, -0.5f, 0.0f}, {0.0f, 1.0f, 0.0f}, {1.0f, 0.0f}},
-            {{0.5f, 0.5f, 0.0f}, {0.0f, 0.0f, 1.0f}, {1.0f, 1.0f}},
-            {{-0.5f, 0.5f, 0.0f}, {1.0f, 1.0f, 1.0f}, {0.0f, 1.0f}},
-
-            {{-0.5f, -0.5f, -0.5f}, {1.0f, 0.0f, 0.0f}, {0.0f, 0.0f}},
-            {{0.5f, -0.5f, -0.5f}, {0.0f, 1.0f, 0.0f}, {1.0f, 0.0f}},
-            {{0.5f, 0.5f, -0.5f}, {0.0f, 0.0f, 1.0f}, {1.0f, 1.0f}},
-            {{-0.5f, 0.5f, -0.5f}, {1.0f, 1.0f, 1.0f}, {0.0f, 1.0f}}
-        };
-        std::vector<uint16_t> indices = {
-            0, 1, 2, 2, 3, 0,
-            4, 5, 6, 6, 7, 4
-        };
+        Model model;
     };
 }

--- a/src/scene/Scene.cpp
+++ b/src/scene/Scene.cpp
@@ -2,19 +2,20 @@
 #include "Scene.h"
 #include "Components.h"
 #include "window/KeyEvent.h"
-#include "graphics/Model.h"
+#include "graphics/Mesh.h"
+#include "graphics/ViewProjection.h"
 
 namespace Blink {
-    Scene::Scene(const SceneConfig& config) : config(config), player(registry.create()) {
-        initializeEntityComponents();
+    Scene::Scene(const SceneConfig& config) : config(config), player(registry.create()), enemy(registry.create()) {
+        initializePlayerComponents();
+        initializeEnemyComponents();
         config.luaEngine->createEntityBindings(&registry);
     }
 
     Scene::~Scene() {
-        BL_LOG_DEBUG("DESTROYING SCENE");
-        for (entt::entity entity : registry.view<ModelComponent>()) {
-            const ModelComponent& modelComponent = registry.get<ModelComponent>(entity);
-            config.renderer->destroyModel(modelComponent.model);
+        for (const entt::entity entity : registry.view<MeshComponent>()) {
+            const MeshComponent& meshComponent = registry.get<MeshComponent>(entity);
+            config.renderer->destroyMesh(meshComponent.mesh);
         }
         registry.clear();
     }
@@ -22,55 +23,32 @@ namespace Blink {
     void Scene::onEvent(Event& event) {
         if (event.type == EventType::KeyPressed && event.as<KeyPressedEvent>().key == Key::F1) {
             config.luaEngine->reloadScripts(&registry);
-            BL_LOG_INFO("Recreated entity bindings");
         }
     }
 
     void Scene::update(double timestep) {
         config.luaEngine->updateEntityBindings(&registry, timestep);
+        for (const entt::entity entity : registry.view<TransformComponent, MeshComponent>()) {
+            auto& transformComponent = registry.get<TransformComponent>(entity);
+            glm::mat4 translation = glm::translate(glm::mat4(1.0f), transformComponent.position);
+            glm::mat4 rotation = glm::mat4(1.0f);
+            glm::mat4 scale = glm::mat4(1.0f);
+            auto& meshComponent = registry.get<MeshComponent>(entity);
+            meshComponent.mesh.model = translation * rotation * scale;
+        }
     }
 
     void Scene::render() {
-        // TRANSLATION
-        auto& transformComponent = registry.get<TransformComponent>(player);
-        glm::mat4 translation = glm::translate(glm::mat4(1.0f), transformComponent.position);
-
-        // ROTATION
-        static auto startTime = std::chrono::high_resolution_clock::now();
-        auto currentTime = std::chrono::high_resolution_clock::now();
-        float time = std::chrono::duration<float, std::chrono::seconds::period>(currentTime - startTime).count();
-        float angle = time * glm::radians(90.0f);
-        constexpr glm::vec3 axis(0.0f, 0.0f, 1.0f);
-        glm::mat4 rotation = glm::rotate(glm::mat4(1.0f), angle, axis);
-
-        // SCALE
-        glm::mat4 scale = glm::mat4(1.0f);
-
-        glm::mat4 modelMatrix = translation * rotation * scale;
-        glm::mat4 viewMatrix = config.camera->getViewMatrix();
-        glm::mat4 projectionMatrix = config.camera->getProjectionMatrix();
-
-        Frame frame{};
-        frame.view = &viewMatrix;
-        frame.projection = &projectionMatrix;
-
-        if (!config.renderer->beginFrame(frame)) {
-            return;
+        ViewProjection viewProjection{};
+        viewProjection.view = config.camera->getView();
+        viewProjection.projection = config.camera->getProjection();
+        for (const entt::entity entity : registry.view<MeshComponent>()) {
+            auto& meshComponent = registry.get<MeshComponent>(entity);
+            config.renderer->renderMesh(meshComponent.mesh, viewProjection);
         }
-
-        auto& modelComponent = registry.get<ModelComponent>(player);
-        Model& model = modelComponent.model;
-
-        model.modelMatrix = modelMatrix;
-        config.renderer->render(frame, model);
-
-        model.modelMatrix = glm::translate(glm::mat4(1.0f), transformComponent.position + 1.0f);
-        config.renderer->render(frame, model);
-
-        config.renderer->endFrame();
     }
 
-    void Scene::initializeEntityComponents() {
+    void Scene::initializePlayerComponents() {
         TransformComponent transformComponent{};
         transformComponent.position = { 2.0f, 2.0f, 2.0f };
         registry.emplace<TransformComponent>(player, transformComponent);
@@ -84,8 +62,22 @@ namespace Blink {
         luaComponent.filepath = "lua/player.out";
         registry.emplace<LuaComponent>(player, luaComponent);
 
-        ModelComponent modelComponent{};
-        modelComponent.model = config.renderer->createModel();
-        registry.emplace<ModelComponent>(player, modelComponent);
+        MeshComponent meshComponent{};
+        meshComponent.mesh = config.renderer->createMesh();
+        registry.emplace<MeshComponent>(player, meshComponent);
+    }
+
+    void Scene::initializeEnemyComponents() {
+        TransformComponent transformComponent{};
+        transformComponent.position = { 1.75f, 1.75f, 1.75f };
+        registry.emplace<TransformComponent>(enemy, transformComponent);
+
+        TagComponent tagComponent{};
+        tagComponent.tag = "Enemy";
+        registry.emplace<TagComponent>(enemy, tagComponent);
+
+        MeshComponent meshComponent{};
+        meshComponent.mesh = config.renderer->createMesh();
+        registry.emplace<MeshComponent>(enemy, meshComponent);
     }
 }

--- a/src/scene/Scene.cpp
+++ b/src/scene/Scene.cpp
@@ -20,7 +20,7 @@ namespace Blink {
         }
     }
 
-    glm::mat4 Scene::update(double timestep) {
+    void Scene::update(double timestep) {
         config.luaEngine->updateEntityBindings(&registry, timestep);
 
         // TRANSLATION
@@ -38,7 +38,20 @@ namespace Blink {
         // SCALE
         glm::mat4 scale = glm::mat4(1.0f);
 
-        return translation * rotation * scale;
+        glm::mat4 modelMatrix = translation;// * rotation * scale;
+        glm::mat4 viewMatrix = config.camera->getViewMatrix();
+        glm::mat4 projectionMatrix = config.camera->getProjectionMatrix();
+
+        Frame frame{};
+        frame.model = &modelMatrix;
+        frame.view = &viewMatrix;
+        frame.projection = &projectionMatrix;
+
+        auto& modelComponent = registry.get<ModelComponent>(player);
+        frame.vertices = &modelComponent.vertices;
+        frame.indices = &modelComponent.indices;
+
+        config.renderer->render(frame);
     }
 
     void Scene::initializeEntityComponents() {
@@ -54,5 +67,8 @@ namespace Blink {
         luaComponent.type = "Player";
         luaComponent.filepath = "lua/player.out";
         registry.emplace<LuaComponent>(player, luaComponent);
+
+        ModelComponent modelComponent{};
+        registry.emplace<ModelComponent>(player, modelComponent);
     }
 }

--- a/src/scene/Scene.h
+++ b/src/scene/Scene.h
@@ -21,6 +21,7 @@ namespace Blink {
         SceneConfig config;
         entt::registry registry;
         entt::entity player;
+        entt::entity enemy;
 
     public:
         explicit Scene(const SceneConfig& config);
@@ -34,6 +35,8 @@ namespace Blink {
         void render();
 
     private:
-        void initializeEntityComponents();
+        void initializePlayerComponents();
+
+        void initializeEnemyComponents();
     };
 }

--- a/src/scene/Scene.h
+++ b/src/scene/Scene.h
@@ -31,6 +31,8 @@ namespace Blink {
 
         void update(double timestep);
 
+        void render();
+
     private:
         void initializeEntityComponents();
     };

--- a/src/scene/Scene.h
+++ b/src/scene/Scene.h
@@ -1,7 +1,9 @@
 #pragma once
 
 #include "window/Keyboard.h"
+#include "graphics/Renderer.h"
 #include "lua/LuaEngine.h"
+#include "scene/Camera.h"
 
 #include <entt/entt.hpp>
 #include <glm/glm.hpp>
@@ -9,7 +11,9 @@
 namespace Blink {
     struct SceneConfig {
         Keyboard* keyboard = nullptr;
+        Renderer* renderer = nullptr;
         LuaEngine* luaEngine = nullptr;
+        Camera* camera = nullptr;
     };
 
     class Scene {
@@ -25,7 +29,7 @@ namespace Blink {
 
         void onEvent(Event& event);
 
-        glm::mat4 update(double timestep);
+        void update(double timestep);
 
     private:
         void initializeEntityComponents();

--- a/src/system/FileSystem.cpp
+++ b/src/system/FileSystem.cpp
@@ -26,7 +26,7 @@ namespace Blink {
         return std::filesystem::exists(path);
     }
 
-    std::vector<char> FileSystem::readBytes(const char* path) const noexcept(false) {
+    std::vector<char> FileSystem::readBytes(const char* path) const {
         if (!exists(path)) {
             BL_THROW("Could not find file [" + std::string(path) + "]");
         }
@@ -42,7 +42,7 @@ namespace Blink {
         return buffer;
     }
 
-    Image FileSystem::readImage(const char* path) const noexcept(false) {
+    Image FileSystem::readImage(const char* path) const {
         int32_t width;
         int32_t height;
         int32_t channels;

--- a/src/system/FileSystem.h
+++ b/src/system/FileSystem.h
@@ -25,8 +25,8 @@ namespace Blink {
     public:
         bool exists(const char* path) const;
 
-        std::vector<char> readBytes(const char* path) const noexcept(false);
+        std::vector<char> readBytes(const char* path) const;
 
-        Image readImage(const char* path) const noexcept(false);
+        Image readImage(const char* path) const;
     };
 }


### PR DESCRIPTION
- [x] Added `Mesh` that contains its own vertex, index and uniform buffers, texture and descriptor set
- [x] Added `MeshComponent` that contains a `Mesh` and is attached to entities in the scene
- [x] Updated `Renderer` to draw multiple meshes in a frame

 